### PR TITLE
Correct import directives

### DIFF
--- a/Connectivity/Classes/Reachability/Reachability.h
+++ b/Connectivity/Classes/Reachability/Reachability.h
@@ -7,9 +7,6 @@
  */
 
 #import <Foundation/Foundation.h>
-#import <SystemConfiguration/SystemConfiguration.h>
-#import <netinet/in.h>
-
 
 typedef enum : NSInteger {
 	NotReachable = 0,

--- a/Connectivity/Classes/Reachability/Reachability.m
+++ b/Connectivity/Classes/Reachability/Reachability.m
@@ -11,9 +11,7 @@
 #import <netdb.h>
 #import <sys/socket.h>
 #import <netinet/in.h>
-
-#import <CoreFoundation/CoreFoundation.h>
-
+#import <SystemConfiguration/SystemConfiguration.h>
 #import "Reachability.h"
 
 #pragma mark IPv6 Support


### PR DESCRIPTION
The file Reachability.h was importing system headers that are not needed at that scope. Moving them within the implementation file reduces the chances of having cycle dependencies when importing Reachability in other parts of a project, especially when used with CocoaPods.