### PR TITLE
Bump minimum iOS version in podspec to 9.0 to match SwiftPM.

### DIFF
--- a/Connectivity.podspec
+++ b/Connectivity.podspec
@@ -11,7 +11,7 @@ Connectivity wraps Apple's Reachability code to provide a reliable measure of wh
   s.license          = { :type => 'MIT', :file => 'LICENSE' }
   s.author           = { 'Ross Butler' => 'github@rwbutler.com' }
   s.source           = { :git => 'https://github.com/rwbutler/Connectivity.git', :tag => s.version.to_s }
-  s.ios.deployment_target = '8.0'
+  s.ios.deployment_target = '9.0'
   s.tvos.deployment_target = '9.0'
   s.macos.deployment_target = '10.10'
   s.frameworks      = 'SystemConfiguration'


### PR DESCRIPTION
Minimum iOS version was bumped to iOS 9.0 in `Package.swift` and project settings, but not yet in the Podspec, still causing the warning to show up when using Cocoapods.

This fixes that.