### PR TITLE
Fix breaking change in v6.1.0

### DIFF
--- a/Connectivity/Classes/Connectivity.swift
+++ b/Connectivity/Classes/Connectivity.swift
@@ -50,6 +50,25 @@ public class Connectivity: NSObject {
     /// network actually being available.
     public var connectivityCheckLatency: Double = 0.5
     
+    @available(*, deprecated, renamed: "connectivityURLRequests")
+    public var connectivityURLs: [URL] {
+        get {
+            var urls = [URL]()
+            connectivityURLRequests.forEach({ urlRequest in
+                guard let url = urlRequest.url else {
+                    return
+                }
+                urls.append(url)
+            })
+            return urls
+        }
+        set {
+            connectivityURLRequests = newValue.map {
+                URLRequest(url: $0)
+            }
+        }
+    }
+
     /// URLs to contact in order to check connectivity
     public var connectivityURLRequests: [URLRequest] = Connectivity
         .defaultConnectivityURLRequests(shouldUseHTTPS: Connectivity.isHTTPSOnly) {


### PR DESCRIPTION
This PR adds back the `connectivityURLs` property that was removed in version 6.1.0, but now it has a getter and setter that uses the new `connectivityURLRequests` property.

`connectivityURLs` is marked as deprecated and will produce the following warning during compilation if used:
```
'connectivityURLs' is deprecated: renamed to 'connectivityURLRequests'
```

This prevents existing code from breaking and allows developers to upgrade to the new property in their own time. In a v7 major release, the `connectivityURLs` property can be completely removed.

Fixes https://github.com/rwbutler/Connectivity/issues/78

@rwbutler Could you take a look?